### PR TITLE
fix the config object being null when saving sometimes

### DIFF
--- a/src/main/java/me/justramon/ircbot/justabotx/config/ConfigHandler.java
+++ b/src/main/java/me/justramon/ircbot/justabotx/config/ConfigHandler.java
@@ -42,7 +42,7 @@ public class ConfigHandler {
             e.printStackTrace();
         }
 
-        Config config = new Config();
+        config = new Config();
 
         config.nick = "JustABotX";
         config.devnick = "JABXDev";


### PR DESCRIPTION
The config object was declared locally instead of using the global object. This only posed a problem when saving it, when the config file doesn't exist yet, because where it is read, the global object is used.
